### PR TITLE
Fixed zero priority fee

### DIFF
--- a/pumpswap_sdk/core/buy_service.py
+++ b/pumpswap_sdk/core/buy_service.py
@@ -47,7 +47,8 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
             payer.pubkey(), payer.pubkey(), mint_pubkey
         )
 
-        ix = [
+        if config.swap_priority_fee > 0:
+            ix = [
             set_compute_unit_price(config.swap_priority_fee),
             wsol_ix_list[0],
             wsol_ix_list[1],
@@ -55,7 +56,14 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
             buy_ix,
             wsol_ix_list[2]
         ]
-
+        else:
+            ix = [
+            wsol_ix_list[0],
+            wsol_ix_list[1],
+            token_account_ix,
+            buy_ix,
+            wsol_ix_list[2]
+        ]
 
         tx_buy = await send_transaction(client, payer, [payer], ix)
         if not tx_buy:

--- a/pumpswap_sdk/core/sell_service.py
+++ b/pumpswap_sdk/core/sell_service.py
@@ -51,8 +51,10 @@ async def sell_pumpswap_token(mint: str, token_amount: float, payer_pk: str):
                 TOKEN_PROGRAM_ID, wsol_token_account, payer.pubkey(), payer.pubkey()
             )
         )
+        ix = []
 
-        ix = [set_compute_unit_price(config.swap_priority_fee)]
+        if config.swap_priority_fee > 0:
+            ix = [set_compute_unit_price(config.swap_priority_fee)]
         if wsol_token_account_instructions:
             ix.append(wsol_token_account_instructions)
         ix.append(sell_ix)
@@ -89,7 +91,7 @@ async def sell_pumpswap_token(mint: str, token_amount: float, payer_pk: str):
     except Exception as e:
         return  {
                 "status": False,
-                "message": "Transaction Confirmation Failed",
+                "message": f"Transaction Confirmation Failed {e}",
                 "data": None
         }
 


### PR DESCRIPTION
**Pull Request Title**

Fix bug with zero priority fee and compute unit price handling

**Description**

This PR fixes the bug where the transaction incorrectly sets the compute unit price when the priority fee is zero. Now, the transaction does not set the compute unit price if the priority fee is 0, which aligns with expected behavior.

**Related Issue**

- Closes #3 
