### PR TITLE
5 issues with sell function env config limitations incorrect slippage

### DIFF
--- a/pumpswap_sdk/config/settings.py
+++ b/pumpswap_sdk/config/settings.py
@@ -7,8 +7,8 @@ load_dotenv()
 class Settings(BaseSettings):
     """Global settings and bot configurations"""
     https_rpc_endpoint: str = Field("https://api.mainnet-beta.solana.com", env="HTTPS_RPC_ENDPOINT")
-    buy_slippage: float = Field(0.3, env="BUY_SLIPPAGE")
-    sell_slippage: float = Field(0.3, env="SELL_SLIPPAGE")
+    buy_slippage: float = Field(0.3, env="BUY_SLIPPAGE", ge=0, le=99)
+    sell_slippage: float = Field(0.3, env="SELL_SLIPPAGE", ge=0, le=99)
     swap_priority_fee: int = Field(1_500_000, env="SWAP_PRIORITY_FEE")
 
     class Config:

--- a/pumpswap_sdk/config/settings.py
+++ b/pumpswap_sdk/config/settings.py
@@ -14,3 +14,4 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "allow"

--- a/pumpswap_sdk/core/buy_service.py
+++ b/pumpswap_sdk/core/buy_service.py
@@ -98,7 +98,7 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
     except Exception as e:
         return  {
                 "status": False,
-                "message": "Transaction Confirmation Failed",
+                "message": f"Transaction Confirmation Failed {str(e)}",
                 "data": None
         }
 

--- a/pumpswap_sdk/core/buy_service.py
+++ b/pumpswap_sdk/core/buy_service.py
@@ -90,7 +90,7 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
             "message": "Transaction completed successfully",
             "data": {
                 "tx_id": tx_buy.value,
-                "amount": token_amount,
+                "amount": round(token_amount, 6),
                 "price": token_price_sol
             }
         }

--- a/pumpswap_sdk/core/buy_service.py
+++ b/pumpswap_sdk/core/buy_service.py
@@ -28,7 +28,7 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
     amount_lamports = int(sol_amount * LAMPORTS_PER_SOL)
     token_price_sol = await get_pumpswap_price(mint_pubkey)
     token_amount = sol_amount / token_price_sol
-    max_amount_lamports = int(amount_lamports * (1 + config.buy_slippage))
+    max_amount_lamports = int(amount_lamports * (1 + (config.buy_slippage / 100)))
 
     if config.buy_slippage <= 0:
         max_amount_lamports += int(0.0001 * LAMPORTS_PER_SOL)  # Add base slippage if slippage is not set

--- a/pumpswap_sdk/core/sell_service.py
+++ b/pumpswap_sdk/core/sell_service.py
@@ -94,7 +94,7 @@ async def sell_pumpswap_token(mint: str, token_amount: float, payer_pk: str):
     except Exception as e:
         return  {
                 "status": False,
-                "message": f"Transaction Confirmation Failed {e}",
+                "message": f"Transaction Confirmation Failed {str(e)}",
                 "data": None
         }
 

--- a/pumpswap_sdk/core/sell_service.py
+++ b/pumpswap_sdk/core/sell_service.py
@@ -29,7 +29,7 @@ async def sell_pumpswap_token(mint: str, token_amount: float, payer_pk: str):
         min_sol_output_lamports = int(0)
     
     else:
-        slippage_factor = 1 - config.sell_slippage
+        slippage_factor = 1 - (config.sell_slippage / 100)
         min_sol_output = token_amount * token_price_sol
         min_sol_output_lamports = int(min_sol_output * slippage_factor * LAMPORTS_PER_SOL)
 


### PR DESCRIPTION
This pull request addresses the following issues:
	1.	.env Config Limitations
	2.	Slippage Range Correction - Slippage is now expected as a percentage between 0 and 100, not 0 to 1.
	3.	Floating-Point Precision in Amounts
	4.	Capped buy_result['data']['amount'] to six decimal places

Additional Context
	•	Related Issue: #5 