### PR TITLE
Fix Swap When Pool Base Mint is WSOL

### DIFF
--- a/pumpswap_sdk/core/buy_service.py
+++ b/pumpswap_sdk/core/buy_service.py
@@ -82,7 +82,7 @@ async def buy_pumpswap_token(mint: str, sol_amount: float, payer_pk: str):
         if not tx_buy:
             return {
                 "status": False,
-                "message": "Transaction Failed",
+                "message": f"Transaction Failed {tx_buy}",
                 "data": None
             }
 

--- a/pumpswap_sdk/core/pool_service.py
+++ b/pumpswap_sdk/core/pool_service.py
@@ -9,43 +9,55 @@ from pumpswap_sdk.utils.pool import PumpPool
 async def get_pumpswap_pair_address(mint_address: Pubkey):
 
     client: AsyncClient = await SolanaClient().get_instance()
-    filters = [
-        MemcmpOpts(offset=43, bytes=str(mint_address)),  # Matching mint address
-        MemcmpOpts(offset=75, bytes=str(constants.WSOL_TOKEN_ACCOUNT))  # Matching WSOL token account
+    search_orders = [
+        (mint_address, constants.WSOL_TOKEN_ACCOUNT),
+        (constants.WSOL_TOKEN_ACCOUNT, mint_address)
     ]
-    
-    response = await client.get_program_accounts(
-        constants.PUMP_AMM_PROGRAM_ID,
-        encoding="base64",  
-        filters=filters
-    )
 
-    if response.value:
-        pools = response.value[0].pubkey 
-        return pools
-    else:
-        return None
+    for token_a, token_b in search_orders:
+        filters = [
+            MemcmpOpts(offset=43, bytes=str(token_a)),
+            MemcmpOpts(offset=75, bytes=str(token_b)),
+        ]
+
+        response = await client.get_program_accounts(
+            constants.PUMP_AMM_PROGRAM_ID,
+            filters=filters,
+            encoding='base64'
+        )
+
+        if response.value:
+            pools = response.value[0].pubkey 
+            return pools
+        else:
+            return None
 
 
 
 async def get_pumpswap_pool_data(mint: Pubkey):
 
     client: AsyncClient = await SolanaClient.get_instance()
-    filters = [
-        MemcmpOpts(offset=43, bytes=str(mint)),
-        MemcmpOpts(offset=75, bytes=str(constants.WSOL_TOKEN_ACCOUNT)),
+    search_orders = [
+        (mint, constants.WSOL_TOKEN_ACCOUNT),
+        (constants.WSOL_TOKEN_ACCOUNT, mint)
     ]
 
-    resp = await client.get_program_accounts(
-        constants.PUMP_AMM_PROGRAM_ID, 
-        filters=filters, 
-        encoding='base64'
-    )
+    for token_a, token_b in search_orders:
+        filters = [
+            MemcmpOpts(offset=43, bytes=str(token_a)),
+            MemcmpOpts(offset=75, bytes=str(token_b)),
+        ]
 
-    if resp.value:
-        account_data = resp.value[0].account.data  # base64 encoded
-        binary_data = bytes(account_data)  
-        pool_data = PumpPool(binary_data)
-        return pool_data
-    else:
-        raise Exception("No matching pool found")
+        response = await client.get_program_accounts(
+            constants.PUMP_AMM_PROGRAM_ID,
+            filters=filters,
+            encoding='base64'
+        )
+
+        if response.value:
+            account_data = response.value[0].account.data  # base64 encoded
+            binary_data = bytes(account_data)  
+            pool_data = PumpPool(binary_data)
+            return pool_data
+
+    raise Exception("No matching pool found")

--- a/pumpswap_sdk/core/pool_service.py
+++ b/pumpswap_sdk/core/pool_service.py
@@ -29,8 +29,7 @@ async def get_pumpswap_pair_address(mint_address: Pubkey):
         if response.value:
             pools = response.value[0].pubkey 
             return pools
-        else:
-            return None
+    raise Exception("No matching pool found")
 
 
 

--- a/pumpswap_sdk/core/price_service.py
+++ b/pumpswap_sdk/core/price_service.py
@@ -3,6 +3,7 @@ from solana.rpc.async_api import AsyncClient
 
 from pumpswap_sdk.config.client import SolanaClient
 from pumpswap_sdk.core.pool_service import get_pumpswap_pool_data
+from pumpswap_sdk.utils.constants import WSOL_TOKEN_ACCOUNT
 from pumpswap_sdk.utils.pool import PumpPool
 
 
@@ -15,5 +16,7 @@ async def get_pumpswap_price(mint_address: Pubkey):
     qoute_balance = await client.get_token_account_balance(data.pool_quote_token_account)
     base_balance = await client.get_token_account_balance(data.pool_base_token_account)
 
-    price = qoute_balance.value.ui_amount / base_balance.value.ui_amount
-    return price
+    if data.base_mint == WSOL_TOKEN_ACCOUNT:
+        return base_balance.value.ui_amount / qoute_balance.value.ui_amount
+    else:
+        return qoute_balance.value.ui_amount / base_balance.value.ui_amount

--- a/pumpswap_sdk/utils/instruction.py
+++ b/pumpswap_sdk/utils/instruction.py
@@ -8,31 +8,46 @@ from pumpswap_sdk.utils.pool import PumpPool
 
 
 
-async def create_pumpswap_buy_instruction(pool_id: Pubkey, user: Pubkey, mint: Pubkey, token_amount: float, quote_account: Pubkey, max_amount_lamports: int):
+async def create_pumpswap_buy_instruction(pool_data: PumpPool, pool_id: Pubkey, user: Pubkey, mint: Pubkey, token_amount: float, wsol_token_account: Pubkey, max_amount_lamports: int):
     
-    # Prepare the accounts for the buy transaction
-    user_base_token_account = get_associated_token_address(user, mint)
-    pool_data: PumpPool = await get_pumpswap_pool_data(mint)
+    if pool_data.base_mint == WSOL_TOKEN_ACCOUNT:
+        user_base_token_account = wsol_token_account
+        user_quote_token_account = get_associated_token_address(user, mint)
+        data = (
+            SELL_DISCRIMINATOR
+            + struct.pack("<Q", max_amount_lamports)  # Max lamports allowed for the transaction
+            + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))  # Convert token amount to smallest unit
+        )
+    
+    else:
+        user_base_token_account = get_associated_token_address(user, mint)
+        user_quote_token_account = wsol_token_account
+        data = (
+            BUY_DISCRIMINATOR
+            + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))  # Convert token amount to smallest unit
+            + struct.pack("<Q", max_amount_lamports)  # Max lamports allowed for the transaction
+        )
 
     pool_base_token_account = pool_data.pool_base_token_account
     pool_quote_token_account = pool_data.pool_quote_token_account
 
     vault_auth_seeds = [b"creator_vault", bytes(pool_data.coin_creator)]
     vault_auth_pda, _ = Pubkey.find_program_address(vault_auth_seeds, PUMP_AMM_PROGRAM_ID)
-    vault_ata = get_associated_token_address(vault_auth_pda, WSOL_TOKEN_ACCOUNT)
+    vault_ata = get_associated_token_address(vault_auth_pda, pool_data.quote_mint)
+    fee_recipient_ata = get_associated_token_address(FEE_RECIPIENT, pool_data.quote_mint)
 
     accounts = [
         AccountMeta(pubkey=pool_id, is_signer=False, is_writable=False),
         AccountMeta(pubkey=user, is_signer=True, is_writable=True),
         AccountMeta(pubkey=GLOBAL, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=mint, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=WSOL_TOKEN_ACCOUNT, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=pool_data.base_mint, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=pool_data.quote_mint, is_signer=False, is_writable=False),
         AccountMeta(pubkey=user_base_token_account, is_signer=False, is_writable=True),
-        AccountMeta(pubkey=quote_account, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=user_quote_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=pool_base_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=pool_quote_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=FEE_RECIPIENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=FEE_RECIPIENT_ATA, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=fee_recipient_ata, is_signer=False, is_writable=True),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYSTEM_PROGRAM, is_signer=False, is_writable=False),
@@ -43,43 +58,52 @@ async def create_pumpswap_buy_instruction(pool_id: Pubkey, user: Pubkey, mint: P
         AccountMeta(pubkey=vault_auth_pda, is_signer=False, is_writable=False),
     ]
     
-    data = (
-        BUY_DISCRIMINATOR
-        + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))  # Convert token amount to smallest unit
-        + struct.pack("<Q", max_amount_lamports)  # Max lamports allowed for the transaction
-    )
-    
-    # Create the instruction
     return accounts, data
 
 
 
 
-async def create_pumpswap_sell_instruction(pool_id: Pubkey, user: Pubkey, mint: Pubkey, token_amount: float, quote_account: Pubkey, min_sol_lamports: int):
+async def create_pumpswap_sell_instruction(pool_data: PumpPool, pool_id: Pubkey, user: Pubkey, token_amount: int, quote_account: Pubkey, min_sol_lamports: int):
     
-    # Prepare the accounts for the buy transaction
-    user_base_token_account = get_associated_token_address(user, mint)
-    pool_data: PumpPool = await get_pumpswap_pool_data(mint)
+    if pool_data.base_mint == WSOL_TOKEN_ACCOUNT:
+        data = (
+            BUY_DISCRIMINATOR
+            + struct.pack("<Q", int(min_sol_lamports))
+            + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))
+        )
+        print(min_sol_lamports, token_amount)
+    
+    else:
+        data = (
+            SELL_DISCRIMINATOR
+            + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))
+            + struct.pack("<Q", int(min_sol_lamports))
+        )
+
+
+    user_base_token_account = get_associated_token_address(user, pool_data.base_mint)
+    user_quote_token_account =  get_associated_token_address(user, pool_data.quote_mint)
 
     pool_base_token_account = pool_data.pool_base_token_account
     pool_quote_token_account = pool_data.pool_quote_token_account
 
     vault_auth_seeds = [b"creator_vault", bytes(pool_data.coin_creator)]
     vault_auth_pda, _ = Pubkey.find_program_address(vault_auth_seeds, PUMP_AMM_PROGRAM_ID)
-    vault_ata = get_associated_token_address(vault_auth_pda, WSOL_TOKEN_ACCOUNT)
+    vault_ata = get_associated_token_address(vault_auth_pda, pool_data.quote_mint)
+    fee_recipient_ata = get_associated_token_address(FEE_RECIPIENT, pool_data.quote_mint)
 
     accounts = [
         AccountMeta(pubkey=pool_id, is_signer=False, is_writable=False),
         AccountMeta(pubkey=user, is_signer=True, is_writable=True),
         AccountMeta(pubkey=GLOBAL, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=mint, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=WSOL_TOKEN_ACCOUNT, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=pool_data.base_mint, is_signer=False, is_writable=False),
+        AccountMeta(pubkey=pool_data.quote_mint, is_signer=False, is_writable=False),
         AccountMeta(pubkey=user_base_token_account, is_signer=False, is_writable=True),
-        AccountMeta(pubkey=quote_account, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=user_quote_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=pool_base_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=pool_quote_token_account, is_signer=False, is_writable=True),
         AccountMeta(pubkey=FEE_RECIPIENT, is_signer=False, is_writable=False),
-        AccountMeta(pubkey=FEE_RECIPIENT_ATA, is_signer=False, is_writable=True),
+        AccountMeta(pubkey=fee_recipient_ata, is_signer=False, is_writable=True),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=TOKEN_PROGRAM_ID, is_signer=False, is_writable=False),
         AccountMeta(pubkey=SYSTEM_PROGRAM, is_signer=False, is_writable=False),
@@ -89,12 +113,5 @@ async def create_pumpswap_sell_instruction(pool_id: Pubkey, user: Pubkey, mint: 
         AccountMeta(pubkey=vault_ata, is_signer=False, is_writable=True),
         AccountMeta(pubkey=vault_auth_pda, is_signer=False, is_writable=False),
     ]
-    
-    data = (
-        SELL_DISCRIMINATOR
-        + struct.pack("<Q", int(token_amount * TOKEN_DECIMALS))
-        + struct.pack("<Q", min_sol_lamports)
-    )
-    
-    # Create the instruction
+   
     return accounts, data

--- a/pumpswap_sdk/utils/process_tx.py
+++ b/pumpswap_sdk/utils/process_tx.py
@@ -3,6 +3,7 @@ from pumpswap_sdk.core.pool_service import get_pumpswap_pool_data
 from pumpswap_sdk.utils.constants import *
 from pumpswap_sdk.utils.pool import PumpPool
 from solana.rpc.async_api import AsyncClient
+from spl.token.instructions import get_associated_token_address
 
 async def handle_pumpswap_buy_tx(client: AsyncClient, mint: Pubkey, tx_signature):
     tx_data_json = (await client.get_transaction(tx_signature, commitment="confirmed")).to_json()
@@ -11,33 +12,54 @@ async def handle_pumpswap_buy_tx(client: AsyncClient, mint: Pubkey, tx_signature
     account_keys = tx_data["result"]["transaction"]["message"]["accountKeys"]
     pool_data = await get_pumpswap_pool_data(mint)
 
-    quote_token_index = account_keys.index(str(pool_data.pool_quote_token_account))
-    base_token_index = account_keys.index(str(pool_data.pool_base_token_account))
-
     pre_balances = tx_data["result"]["meta"]["preBalances"]
     post_balances = tx_data["result"]["meta"]["postBalances"]
     pre_token_balances = tx_data["result"]["meta"].get("preTokenBalances", [])
     post_token_balances = tx_data["result"]["meta"].get("postTokenBalances", [])
 
+    # Find indexes for base, quote and fee recipient accounts
+    if pool_data.base_mint == WSOL_TOKEN_ACCOUNT:
+        quote_token_index = account_keys.index(str(pool_data.pool_base_token_account))
+        base_token_index = account_keys.index(str(pool_data.pool_quote_token_account))
+    else:
+        quote_token_index = account_keys.index(str(pool_data.pool_quote_token_account))
+        base_token_index = account_keys.index(str(pool_data.pool_base_token_account))
+
+    fee_recipient_ata = get_associated_token_address(FEE_RECIPIENT, pool_data.quote_mint)
+    fee_recipient_index = account_keys.index(str(fee_recipient_ata))
     sol_amount = (post_balances[quote_token_index] - pre_balances[quote_token_index]) / LAMPORTS_PER_SOL
 
     def get_token_amount_change(account_index: int) -> float:
         pre_amt = post_amt = 0
         decimals = 6  # default fallback
-
         for entry in pre_token_balances:
             if entry["accountIndex"] == account_index:
                 pre_amt = float(entry["uiTokenAmount"]["amount"])
                 decimals = int(entry["uiTokenAmount"]["decimals"])
-
         for entry in post_token_balances:
             if entry["accountIndex"] == account_index:
                 post_amt = float(entry["uiTokenAmount"]["amount"])
-                # if decimals missing in pre, grab from post
-
         return (pre_amt - post_amt) / (10 ** decimals)
 
+    
+    def get_token_fee_received(account_index: int) -> float:
+        pre_amt = post_amt = 0
+        decimals = 6
+        for entry in pre_token_balances:
+            if entry["accountIndex"] == account_index:
+                pre_amt = float(entry["uiTokenAmount"]["amount"])
+                decimals = int(entry["uiTokenAmount"]["decimals"])
+        for entry in post_token_balances:
+            if entry["accountIndex"] == account_index:
+                post_amt = float(entry["uiTokenAmount"]["amount"])
+
+        return (post_amt - pre_amt) / (10 ** decimals)
+
     token_amount = get_token_amount_change(base_token_index)
+
+    if pool_data.base_mint == WSOL_TOKEN_ACCOUNT:
+        fee_amount = get_token_fee_received(fee_recipient_index)
+        token_amount -= fee_amount
 
     return {
         "sol_amount": round(sol_amount, 9),
@@ -53,7 +75,10 @@ async def handle_pumpswap_sell_tx(client: AsyncClient, mint: Pubkey, tx_signatur
     account_keys = tx_data["result"]["transaction"]["message"]["accountKeys"]
     pool_data = await get_pumpswap_pool_data(mint)
 
-    quote_token_index = account_keys.index(str(pool_data.pool_quote_token_account))
+    if pool_data.base_mint == WSOL_TOKEN_ACCOUNT:
+        quote_token_index = account_keys.index(str(pool_data.pool_base_token_account))
+    else:
+        quote_token_index = account_keys.index(str(pool_data.pool_quote_token_account))
 
     pre_balances = tx_data["result"]["meta"]["preBalances"]
     post_balances = tx_data["result"]["meta"]["postBalances"]


### PR DESCRIPTION
**Description:**

This PR addresses a special case in PumpSwap_SDK where the pool’s base mint is WSOL. Although the intended behavior is a “buy” (i.e., receive WSOL in exchange for an SPL token), the transaction fails when using the buy() method.

Instead, the swap only succeeds when routed through the sell() method, effectively treating WSOL as the quote asset despite it being the base mint.

⸻

**What’s Changed:**
	•	Detects when the pool’s base mint is WSOL (So111...)
	•	Routes the transaction through sell() instead of buy() in this case
	•	Ensures correct parameter formatting to complete the transaction successfully

⸻

**Additional Context**
• Related Issue: #2 