### PR TITLE
Handle Migrated Token Pair Detection (Pump.fun ➝ PumpSwap)

### DIFF
--- a/pumpswap_sdk/core/pool_service.py
+++ b/pumpswap_sdk/core/pool_service.py
@@ -23,7 +23,8 @@ async def get_pumpswap_pair_address(mint_address: Pubkey):
         response = await client.get_program_accounts(
             constants.PUMP_AMM_PROGRAM_ID,
             filters=filters,
-            encoding='base64'
+            encoding='base64',
+            commitment="processed"
         )
 
         if response.value:
@@ -50,7 +51,8 @@ async def get_pumpswap_pool_data(mint: Pubkey):
         response = await client.get_program_accounts(
             constants.PUMP_AMM_PROGRAM_ID,
             filters=filters,
-            encoding='base64'
+            encoding='base64',
+            commitment="processed"
         )
 
         if response.value:


### PR DESCRIPTION
**Summary**

This PR addresses an issue where tokens migrated from Pump.fun to PumpSwap fail to have their pair address detected immediately, causing SDK and RPC lookup errors.

------------------------

**Problem**

After migrating a token from Pump.fun to PumpSwap, the pair address is not immediately available via RPC. This results in the SDK failing to find the trading pair, even though it exists. The root cause is the confirmation status — it remains unconfirmed during the migration window.

------------------------

**Solution**

Changed token confirmation status logic to mark migrated tokens as “processed” earlier, allowing the SDK to continue operations.

------------------------

**Developer Note**

If you still encounter this error after the update, it’s recommended to implement a short retry/sleep mechanism on your side. The RPC may need a few seconds to recognize the new pair after migration.

Closes #11 
